### PR TITLE
[DEV] 메시지 답장으로 전송 기능 구현

### DIFF
--- a/.idea/Wa_Bot_Telegram.iml
+++ b/.idea/Wa_Bot_Telegram.iml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module type="PYTHON_MODULE" version="4">
   <component name="NewModuleRootManager">
-    <content url="file://$MODULE_DIR$" />
-    <orderEntry type="inheritedJdk" />
+    <content url="file://$MODULE_DIR$">
+      <excludeFolder url="file://$MODULE_DIR$/venv" />
+    </content>
+    <orderEntry type="jdk" jdkName="Python 3.13 (Wa_Bot_Telegram)" jdkType="Python SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>
 </module>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.8" project-jdk-type="Python SDK" />
+  <component name="Black">
+    <option name="sdkName" value="Python 3.13 (Wa_Bot_Telegram)" />
+  </component>
+  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.13 (Wa_Bot_Telegram)" project-jdk-type="Python SDK" />
 </project>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -1,7 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="AutoImportSettings">
+    <option name="autoReloadType" value="SELECTIVE" />
+  </component>
   <component name="ChangeListManager">
-    <list default="true" id="11ece66c-deef-4556-9599-56171ad1908d" name="Changes" comment="" />
+    <list default="true" id="11ece66c-deef-4556-9599-56171ad1908d" name="Changes" comment="">
+      <change beforePath="$PROJECT_DIR$/.idea/Wa_Bot_Telegram.iml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/Wa_Bot_Telegram.iml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/.idea/misc.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/misc.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/main.py" beforeDir="false" afterPath="$PROJECT_DIR$/main.py" afterDir="false" />
+    </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
     <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
@@ -13,6 +21,10 @@
   <component name="MarkdownSettingsMigration">
     <option name="stateVersion" value="1" />
   </component>
+  <component name="ProjectColorInfo"><![CDATA[{
+  "customColor": "",
+  "associatedIndex": 2
+}]]></component>
   <component name="ProjectId" id="2CNZkChGm0szf1if4C7wxVJ09HP" />
   <component name="ProjectViewState">
     <option name="hideEmptyMiddlePackages" value="true" />
@@ -20,12 +32,50 @@
   </component>
   <component name="PropertiesComponent"><![CDATA[{
   "keyToString": {
+    "Python.Default.executor": "Run",
     "RunOnceActivity.OpenProjectViewOnStart": "true",
     "RunOnceActivity.ShowReadmeOnStart": "true",
     "WebServerToolWindowFactoryState": "false",
-    "last_opened_file_path": "/media/yong/LocalDisk/Projects/Python/Wa_Bot_Telegram"
+    "git-widget-placeholder": "master",
+    "last_opened_file_path": "/media/yong/LocalDisk/Projects/Python/Wa_Bot_Telegram",
+    "nodejs_package_manager_path": "npm",
+    "vue.rearranger.settings.migration": "true"
   }
 }]]></component>
+  <component name="RunManager">
+    <configuration name="Default" type="PythonConfigurationType" factoryName="Python">
+      <module name="Wa_Bot_Telegram" />
+      <option name="ENV_FILES" value="" />
+      <option name="INTERPRETER_OPTIONS" value="" />
+      <option name="PARENT_ENVS" value="true" />
+      <envs>
+        <env name="PYTHONUNBUFFERED" value="1" />
+      </envs>
+      <option name="SDK_HOME" value="" />
+      <option name="SDK_NAME" value="Python 3.13 (Wa_Bot_Telegram)" />
+      <option name="WORKING_DIRECTORY" value="" />
+      <option name="IS_MODULE_SDK" value="false" />
+      <option name="ADD_CONTENT_ROOTS" value="true" />
+      <option name="ADD_SOURCE_ROOTS" value="true" />
+      <EXTENSION ID="PythonCoverageRunConfigurationExtension" runner="coverage.py" />
+      <option name="SCRIPT_NAME" value="$PROJECT_DIR$/main.py" />
+      <option name="PARAMETERS" value="" />
+      <option name="SHOW_COMMAND_LINE" value="false" />
+      <option name="EMULATE_TERMINAL" value="false" />
+      <option name="MODULE_MODE" value="false" />
+      <option name="REDIRECT_INPUT" value="false" />
+      <option name="INPUT_FILE" value="" />
+      <method v="2" />
+    </configuration>
+  </component>
+  <component name="SharedIndexes">
+    <attachedChunks>
+      <set>
+        <option value="bundled-js-predefined-d6986cc7102b-5c90d61e3bab-JavaScript-PY-242.23726.102" />
+        <option value="bundled-python-sdk-5e1850174b45-399fe30bd8c1-com.jetbrains.pycharm.pro.sharedIndexes.bundled-PY-242.23726.102" />
+      </set>
+    </attachedChunks>
+  </component>
   <component name="SpellCheckerSettings" RuntimeDictionaries="0" Folders="0" CustomDictionaries="0" DefaultDictionary="application-level" UseSingleDictionary="true" transferred="true" />
   <component name="TaskManager">
     <task active="true" id="Default" summary="Default task">
@@ -35,10 +85,14 @@
       <option name="presentableId" value="Default" />
       <updated>1658645144006</updated>
       <workItem from="1658645147525" duration="82000" />
+      <workItem from="1732826375621" duration="263000" />
     </task>
     <servers />
   </component>
   <component name="TypeScriptGeneratedFilesManager">
     <option name="version" value="3" />
+  </component>
+  <component name="com.intellij.coverage.CoverageDataManagerImpl">
+    <SUITE FILE_PATH="coverage/Wa_Bot_Telegram$Default.coverage" NAME="Default Coverage Results" MODIFIED="1732826447023" SOURCE_PROVIDER="com.intellij.coverage.DefaultCoverageFileProvider" RUNNER="coverage.py" COVERAGE_BY_TEST_ENABLED="false" COVERAGE_TRACING_ENABLED="false" WORKING_DIRECTORY="" />
   </component>
 </project>

--- a/main.py
+++ b/main.py
@@ -28,10 +28,16 @@ async def sendWaMessage(message, update, context):
                 resultMessageList = resultMessage.split("\\m")
 
                 for resultMessageItem in resultMessageList:
-                    await context.bot.send_message(chat_id=update.effective_chat.id, text=resultMessageItem)
+                    await context.bot.send_message(
+                        chat_id=update.effective_chat.id,
+                        reply_to_message_id=message.message_id,
+                        text=resultMessageItem)
             else:
                 resultMessage = resultMessage.replace("\\n", "\n")
-                await context.bot.send_message(chat_id=update.effective_chat.id, text=resultMessage)
+                await context.bot.send_message(
+                    chat_id=update.effective_chat.id,
+                    reply_to_message_id=message.message_id,
+                    text=resultMessage)
 
 
 def main():


### PR DESCRIPTION
## Summary
메시지를 답장으로 전송하도록 하였습니다.

## Description
- 기존에는 응답을 일반 메시지로 전송하였으나, 원본 메시지에 답장하는 형식으로 전송하도록 아래 코드를 적용하였습니다.
```python
  if resultMessage.find("\\m") > 0:
    resultMessageList = resultMessage.split("\\m")

    for resultMessageItem in resultMessageList:
        await context.bot.send_message(
            chat_id=update.effective_chat.id,
            reply_to_message_id=message.message_id,
            text=resultMessageItem)
  else:
      resultMessage = resultMessage.replace("\\n", "\n")
      await context.bot.send_message(
          chat_id=update.effective_chat.id,
          reply_to_message_id=message.message_id,
          text=resultMessage)
```